### PR TITLE
Space fight collision method refactor + Vector library minor fix

### DIFF
--- a/src/space/encounter.js
+++ b/src/space/encounter.js
@@ -133,8 +133,8 @@ export default class Encounter {
      */
     areColliding(object, other) {
         //forcing both methods to be called, so AoE object can detect object leaving its radius
-        let col1 = object.areColliding(other);
-        let col2 = other.areColliding(object);
+        let col1 = object.collidesWith(other);
+        let col2 = other.collidesWith(object);
         return col1 && col2;
     }
 

--- a/src/space/objects/pattern/encounterObject.js
+++ b/src/space/objects/pattern/encounterObject.js
@@ -157,13 +157,4 @@ export default class EncounterObject {
     }
 
     initialize() {}
-
-    /**
-     * Check if two objects collide, basic circle shape
-     * @param other
-     * @returns {boolean}
-     */
-    areColliding(other) {
-        return (MyMath.distance(this.position,other.position) < this.radius + other.radius);
-    }
 }

--- a/src/space/objects/realization/aoeObject.js
+++ b/src/space/objects/realization/aoeObject.js
@@ -36,8 +36,8 @@ export default class Slow extends EncounterObject {
         this.containing.splice(index, 1);
     }
 
-    areColliding(other) {
-        if (other.areColliding(this)) {
+    collidesWith(other) {
+        if (other.collidesWith(this)) {
             if (this.isContained(other)) {
                 return false;
             }

--- a/src/space/utils/vector.js
+++ b/src/space/utils/vector.js
@@ -180,6 +180,8 @@ export default class Vector {
 
         this.x = this.x / magnitude;
         this.y = this.y / magnitude;
+
+        return this;
     }
 
     /**


### PR DESCRIPTION
Unifies methods for checking collisions from within encounter objects to `collidesWith(other)`. The method `areColliding(other)` was removed. 

Also, member method `normalize` in Vector library fixed to be able to get chained.